### PR TITLE
Caching content based on configured http response codes

### DIFF
--- a/sidekick/middleware/cache/writer.go
+++ b/sidekick/middleware/cache/writer.go
@@ -28,14 +28,15 @@ func (r *CustomWriter) Header() http.Header {
 	return r.ResponseWriter.Header()
 }
 
-func (r *CustomWriter) SetHeader(status int) {
+func (r *CustomWriter) WriteHeader(status int) {
+	r.Logger.Debug("==========-SetHeader-==========")
 	r.status = status
 	r.ResponseWriter.WriteHeader(status)
 }
 
 // Write will write the response body
 func (r *CustomWriter) Write(b []byte) (int, error) {
-	r.Logger.Debug("Writing to cache", zap.String("path", r.path))
+	r.Logger.Debug("Writing customwriter response", zap.String("path", r.path))
 	// content encoding
 	ct := r.Header().Get("Content-Encoding")
 	r.Header().Set("X-WPEverywhere-Cache", "MISS")
@@ -44,15 +45,18 @@ func (r *CustomWriter) Write(b []byte) (int, error) {
 	// check if the response code is in the cache response codes
 	for _, code := range r.cacheResponseCodes {
 		status := strconv.Itoa(r.status)
+		r.Logger.Debug("Checking status code", zap.String("code", code), zap.String("status", status))
 
 		if code == status {
+			r.Logger.Debug("Caching because of status code", zap.String("code", code), zap.String("status", status))
 			bypass = false
 			break
 		}
 
 		// code may be single digit because of wildcard usage (e.g. 2XX, 4XX, 5XX)
 		if len(code) == 1 {
-			if code == status {
+			if code == status[0:1] {
+				r.Logger.Debug("Caching because of wildcard", zap.String("code", code), zap.String("status", status))
 				bypass = false
 				break
 			}


### PR DESCRIPTION
administrators can now set the CACHE_RESPONSE_CODES environment variable to let sidekick know which responses to cache. It defaults to 2XX, 404 & 405.