### PR TITLE
Frankenwp gitpod integration

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,1 @@
+FROM gitpod/workspace-full:latest

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,7 +12,6 @@ ports:
 
 vscode:
   extensions:
-    - TabNine.tabnine-vscode@3.4.14
     - felixfbecker.php-debug@1.16.0
 
 tasks:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,33 @@
+# .gitpod.yml
+
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - port: 8100
+    visibility: public
+  - port: 3311
+  - port: 8086
+    visibility: public
+
+vscode:
+  extensions:
+    - TabNine.tabnine-vscode@3.4.14
+    - felixfbecker.php-debug@1.16.0
+
+tasks:
+  - name: "Generate environment and start Docker Compose"
+    openMode: split-right
+    command: |
+      # Navigate to the Gitpod examples directory
+      cd examples/gitpod
+      
+      # Make generate_env.sh executable and run it to create .env file
+      chmod +x generate_env.sh
+      ./generate_env.sh
+      
+      # Start Docker Compose from the same directory
+      docker-compose up -d
+
+  - name: "Start Terminal"
+    command: clear && echo "Environment setup complete. Ready for WordPress testing on FrankenWP!"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ An enterprise-grade WordPress image built for scale. It uses the new FrankenPHP 
 - [Standard environment with MariaDB & Docker Compose](./examples/basic/compose.yaml)
 - [Debug with XDebug & Docker Compose](./examples/debug/compose.yaml)
 - [SQLite with Docker Compose](./examples/sqlite/compose.yaml)
+- [Gitpod Example](./examples/gitpod/compose.yaml)
 
 ## Whats Included
 

--- a/examples/gitpod/compose.yaml
+++ b/examples/gitpod/compose.yaml
@@ -1,0 +1,62 @@
+services:
+  wordpress:
+    image: wpeverywhere/frankenwp:latest-php8.3
+    restart: always
+    ports:
+      - "8100:80" # HTTP
+    environment:
+      SERVER_NAME: ${SERVER_NAME:-:80}
+      WORDPRESS_DB_HOST: ${DB_HOST:-db}
+      WORDPRESS_DB_USER: ${DB_USER:-exampleuser}
+      WORDPRESS_DB_PASSWORD: ${DB_PASSWORD:-examplepass}
+      WORDPRESS_DB_NAME: ${DB_NAME:-exampledb}
+      WORDPRESS_DEBUG: ${WP_DEBUG:-true}
+      WORDPRESS_TABLE_PREFIX: ${DB_TABLE_PREFIX:-wp_}
+      CACHE_LOC: ${CACHE_LOC:-/var/www/html/wp-content/cache}
+      TTL: ${TTL:-80000}
+      PURGE_PATH: ${PURGE_PATH:-/__cache/purge}
+      PURGE_KEY: ${PURGE_KEY:-}
+      BYPASS_HOME: ${BYPASS_HOME:-false}
+      BYPASS_PATH_PREFIXES: ${BYPASS_PATH_PREFIXES:-/wp-admin,/wp-content,/wp-includes,/wp-json,/feed}
+      CACHE_RESPONSE_CODES: ${CACHE_RESPONSE_CODES:-000}
+      CADDY_GLOBAL_OPTIONS: |
+        email myemail@sample.com
+        auto_https disable_redirects
+        debug
+      WORDPRESS_CONFIG_EXTRA: |
+          define('WP_SITEURL', '${WP_SITEURL}');
+          define('WP_HOME', '${WP_HOME}');
+          
+    #volumes:
+    #  - ./wp-content:/var/www/html/wp-content
+
+    depends_on:
+      - db
+    tty: true
+
+  db:
+    image: mariadb:latest
+    restart: always
+    ports:
+      - ${LOCAL_DB_PORT:-3311}:3306
+    environment:
+      MYSQL_DATABASE: ${DB_NAME:-exampledb}
+      MYSQL_USER: ${DB_USER:-exampleuser}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-examplepass}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-examplepass}
+    volumes:
+      - dbwp:/var/lib/mysql
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    restart: always
+    ports:
+      - ${LOCAL_PHPMYADMIN_PORT:-8086}:80
+    environment:
+      PMA_HOST: db
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-examplepass}
+    depends_on:
+      - db
+
+volumes:
+  dbwp:

--- a/examples/gitpod/compose.yml
+++ b/examples/gitpod/compose.yml
@@ -1,0 +1,62 @@
+services:
+  wordpress:
+    image: wpeverywhere/frankenwp:latest-php8.3
+    restart: always
+    ports:
+      - "8100:80" # HTTP
+    environment:
+      SERVER_NAME: ${SERVER_NAME:-:80}
+      WORDPRESS_DB_HOST: ${DB_HOST:-db}
+      WORDPRESS_DB_USER: ${DB_USER:-exampleuser}
+      WORDPRESS_DB_PASSWORD: ${DB_PASSWORD:-examplepass}
+      WORDPRESS_DB_NAME: ${DB_NAME:-exampledb}
+      WORDPRESS_DEBUG: ${WP_DEBUG:-true}
+      WORDPRESS_TABLE_PREFIX: ${DB_TABLE_PREFIX:-wp_}
+      CACHE_LOC: ${CACHE_LOC:-/var/www/html/wp-content/cache}
+      TTL: ${TTL:-80000}
+      PURGE_PATH: ${PURGE_PATH:-/__cache/purge}
+      PURGE_KEY: ${PURGE_KEY:-}
+      BYPASS_HOME: ${BYPASS_HOME:-false}
+      BYPASS_PATH_PREFIXES: ${BYPASS_PATH_PREFIXES:-/wp-admin,/wp-content,/wp-includes,/wp-json,/feed}
+      CACHE_RESPONSE_CODES: ${CACHE_RESPONSE_CODES:-000}
+      CADDY_GLOBAL_OPTIONS: |
+        email myemail@sample.com
+        auto_https disable_redirects
+        debug
+      WORDPRESS_CONFIG_EXTRA: |
+          define('WP_SITEURL', '${WP_SITEURL}');
+          define('WP_HOME', '${WP_HOME}');
+          
+    #volumes:
+    #  - ./wp-content:/var/www/html/wp-content
+
+    depends_on:
+      - db
+    tty: true
+
+  db:
+    image: mariadb:latest
+    restart: always
+    ports:
+      - ${LOCAL_DB_PORT:-3311}:3306
+    environment:
+      MYSQL_DATABASE: ${DB_NAME:-exampledb}
+      MYSQL_USER: ${DB_USER:-exampleuser}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-examplepass}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-examplepass}
+    volumes:
+      - dbwp:/var/lib/mysql
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    restart: always
+    ports:
+      - ${LOCAL_PHPMYADMIN_PORT:-8086}:80
+    environment:
+      PMA_HOST: db
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-examplepass}
+    depends_on:
+      - db
+
+volumes:
+  dbwp:

--- a/examples/gitpod/generate_env.sh
+++ b/examples/gitpod/generate_env.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Generate the dynamic URL
+url=$(gp url | awk -F"//" '{print $2}')
+url="https://8100-$url/"
+
+# Write to the .env file
+cat <<EOL > .env
+SERVER_NAME=:80
+DB_HOST=db
+DB_USER=exampleuser
+DB_PASSWORD=examplepass
+DB_NAME=exampledb
+WP_DEBUG=true
+DB_TABLE_PREFIX=wp_
+CACHE_LOC=/var/www/html/wp-content/cache
+TTL=80000
+PURGE_PATH=/__cache/purge
+PURGE_KEY=
+BYPASS_HOME=false
+BYPASS_PATH_PREFIXES=/wp-admin,/wp-content,/wp-includes,/wp-json,/feed
+CACHE_RESPONSE_CODES=000
+CADDY_GLOBAL_OPTIONS="email myemail@sample.com
+auto_https disable_redirects
+debug"
+WP_SITEURL=$url
+WP_HOME=$url
+EOL


### PR DESCRIPTION
Hello,

I want to contribute to the Frankenwp repository with a ready-made integration example for a popular https://gitpod.io platform. Gitpod is very useful when developers want to make a quick test using remote (Cloud) resources.

End-users can easily clone their repository with WordPress codebase, and then we could use volume to give examples of how they can spin up FrankenWP to utilize it instantly and make tests.

I have already tested it on my fork and can confirm it works. Please test it from the branch as well.

Thank you!
Nemanja