### PR TITLE
fix: run wpcli as non root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg-dev \
     libwebp-dev \
     libzip-dev \
+    less \
     libmemcached-dev \
     zlib1g-dev
 


### PR DESCRIPTION
Currently I got an error when try to run wp cli as non root

Execute bash = docker exec -u www-data -it [container-id] bash

Then run
```
www-data@114c78c46d9f:~/html$ wp
sh: 1: less: not found
```

It will be fixed by installing `less` package